### PR TITLE
修正了从其他页面转向带有render的页面时会报错的bug

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,9 @@ module.exports = {
 				launchWin.show();
 			});
 			ipcMain.on('main ready', ()=> {
-				launchWin.webContents.send('do finish');
+				try{
+					launchWin.webContents.send('do finish');
+				}catch(e){}
 			});
 			ipcMain.on('do finish', ()=> {
 				launchWin.close();


### PR DESCRIPTION
假设index.html调用了render，然后从index.html跳往book.html，再从book.htmlt跳往index.html时会有error弹窗。加上try catch消除这一弹窗